### PR TITLE
issue #14  グラフの日別を累計に変更

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -63,11 +63,16 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    defaultDataKind: {
+      type: String,
+      required: false,
+      default: 'transition'
     }
   },
   data() {
     return {
-      dataKind: 'transition'
+      dataKind: this.defaultDataKind
     }
   },
   computed: {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -72,7 +72,7 @@ export default {
   },
   data() {
     return {
-      dataKind: this.defaultDataKind
+      dataKind: this.default-DataKind
     }
   },
   computed: {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -64,7 +64,7 @@ export default {
       required: false,
       default: ''
     },
-    defaultDataKind: {
+    default-datakind: {
       type: String,
       required: false,
       default: 'transition'
@@ -72,7 +72,7 @@ export default {
   },
   data() {
     return {
-      dataKind: this.defaultDataKind
+      dataKind: this.default-datakind
     }
   },
   computed: {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -64,7 +64,7 @@ export default {
       required: false,
       default: ''
     },
-    default-datakind: {
+    defaultdatakind: {
       type: String,
       required: false,
       default: 'transition'
@@ -72,7 +72,7 @@ export default {
   },
   data() {
     return {
-      dataKind: this.default-datakind
+      dataKind: this.defaultdatakind
     }
   },
   computed: {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -64,7 +64,7 @@ export default {
       required: false,
       default: ''
     },
-    default-DataKind: {
+    defaultDataKind: {
       type: String,
       required: false,
       default: 'transition'
@@ -72,7 +72,7 @@ export default {
   },
   data() {
     return {
-      dataKind: this.default-DataKind
+      dataKind: this.defaultDataKind
     }
   },
   computed: {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -64,7 +64,7 @@ export default {
       required: false,
       default: ''
     },
-    defaultDataKind: {
+    default-DataKind: {
       type: String,
       required: false,
       default: 'transition'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :defaultDataKind="'cumulative'"
+          :default-DataKind="'cumulative'"
           :url="'http://www.pref.nara.jp/1652.htm'"
         />
       </v-col>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :defaultDataKind="'cumulative'"
+          :default-datakind="'cumulative'"
           :url="'http://www.pref.nara.jp/1652.htm'"
         />
       </v-col>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,6 +26,7 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
+          :defaultDataKind="'cumulative'"
           :url="'http://www.pref.nara.jp/1652.htm'"
         />
       </v-col>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :default-datakind="'cumulative'"
+          :defaultdatakind="'cumulative'"
           :url="'http://www.pref.nara.jp/1652.htm'"
         />
       </v-col>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :default-DataKind="'cumulative'"
+          :defaultDataKind="'cumulative'"
           :url="'http://www.pref.nara.jp/1652.htm'"
         />
       </v-col>


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #{14}

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->

　グラフ表示のデフォルトをビュー側から「日別」「累計」が切り替えられるようにし、
　今回は「累計」表示にする。
　covid19/pages/index.vue
　「日別」　:defaultdatakind="'transition'"
　「累計」　:defaultdatakind="'cumulative'"

