### PR TITLE
サイドバーに一般電話相談窓口、帰国者・接触者相談センター、教育委員会の発表、労働関係の電話相談リンクの追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -169,7 +169,8 @@ export default {
         },
         {
           title: this.$t('Telephone consultation on labor-related matter'),
-          link: 'https://jsite.mhlw.go.jp/nara-roudoukyoku/content/contents/000611858.pdf',
+          link:
+            'https://jsite.mhlw.go.jp/nara-roudoukyoku/content/contents/000611858.pdf',
           divider: true
         },
         {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -93,6 +93,10 @@
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "奈良県総務部知事公室防災統括室",
     "Government official website": "奈良県公式ホームページ",
+    "General Telephone Consultation": "一般電話窓口",
+    "Departures and Contact Person Consultation Center": "帰国者・接触者相談センター",
+    "Board of Education Announcement": "教育委員会の発表",
+    "Telephone consultation on labor-related matter": "労働関係の電話相談",
     "About us": "当サイトについて",
     "Municipalities": "奈良県内各市町村の関連ページ",
     "Other local Government": "他自治体の対策サイト"
@@ -149,6 +153,23 @@ export default {
         {
           title: this.$t('Government official website'),
           link: 'http://www.pref.nara.jp/',
+          divider: true
+        },
+        {
+          title: this.$t('General Telephone Consultation'),
+          link: 'http://www.pref.nara.jp/#002'
+        },
+        {
+          title: this.$t('Departures and Contact Person Consultation Center'),
+          link: 'http://www.pref.nara.jp/#003'
+        },
+        {
+          title: this.$t('Board of Education Announcement'),
+          link: 'http://www.pref.nara.jp/kyoiku/'
+        },
+        {
+          title: this.$t('Telephone consultation on labor-related matter'),
+          link: 'https://jsite.mhlw.go.jp/nara-roudoukyoku/content/contents/000611858.pdf',
           divider: true
         },
         {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

https://github.com/code4nara/covid19/issues/77

<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- サイドバーに以下4点のリンクを追加
  - 一般電話相談窓口
  - 帰国者・接触者相談センター
  - 教育委員会の発表
  - 労働関係の電話相談


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- ローカル環境での動作したスクリーンショット
- 赤枠が追加した箇所

<img width="807" alt="奈良県内の最新感染動向___奈良県_新型コロナウイルス感染症対策サイト（非公式）" src="https://user-images.githubusercontent.com/517800/78551822-54d9f900-7841-11ea-9610-199888802fdf.png">
