### PR TITLE
患者と感染者の区別を表示に反映

### DIFF
--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <confirmed-cases-card
-      :title="$t('入院患者数の状況')"
+      :title="$t('入院者数の状況')"
       :title-id="'details-of-confirmed-cases'"
       :date="Data.main_summary.date"
       :url="'http://www.pref.nara.jp/'"

--- a/components/cards/PatientsAndSickbeds.vue
+++ b/components/cards/PatientsAndSickbeds.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <circle-chart
-      :title="$t('入院患者数と残り病床数')"
+      :title="$t('入院者数と残り病床数')"
       :title-id="'patients-and-sickbeds'"
       :chart-data="sickbedsGraph"
       :date="sickbedsSummary.last_update"

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -93,7 +93,7 @@ export default {
     let title, updatedAt
     switch (this.$route.params.card) {
       case 'details-of-confirmed-cases':
-        title = this.$t('入院患者数の状況')
+        title = this.$t('入院者数の状況')
         // updatedAt = inspectionsSummary.last_update
         // updatedAt = mainSummary.last_update
         updatedAt = Data.main_summary.date
@@ -104,11 +104,11 @@ export default {
         break */
       /*
       case 'number-of-confirmed-cases':
-        title = this.$t('陽性患者数')
+        title = this.$t('陽性者数')
         updatedAt = patients.last_update
         break
       case 'attributes-of-confirmed-cases':
-        title = this.$t('陽性患者の属性')
+        title = this.$t('陽性者の属性')
         updatedAt = patients.last_update
         break
       case 'number-of-tested':
@@ -145,7 +145,7 @@ export default {
         updatedAt = ChiyodaData.date
         break */
       case 'patients-and-sickbeds':
-        title = this.$t('入院患者数と残り病床数')
+        title = this.$t('入院者数と残り病床数')
         updatedAt = sickbedsSummary.last_update
         break
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,7 +22,7 @@
       </v-col> -->
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
-          title="陽性患者数"
+          title="陽性者数"
           :title-id="'number-of-confirmed-cases'"
           :chart-id="'time-bar-chart-patients'"
           :chart-data="patientsGraph"
@@ -33,7 +33,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <data-table
-          :title="'陽性患者の属性'"
+          :title="'陽性者の属性'"
           :title-id="'attributes-of-confirmed-cases'"
           :chart-data="patientsTable"
           :chart-option="{}"

--- a/pages/naracity.vue
+++ b/pages/naracity.vue
@@ -23,7 +23,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
-          title="陽性患者数"
+          title="陽性者数"
           :title-id="'number-of-confirmed-cases'"
           :chart-id="'time-bar-chart-patients'"
           :chart-data="patientsGraph"
@@ -33,7 +33,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <data-table
-          :title="'陽性患者の属性'"
+          :title="'陽性者の属性'"
           :title-id="'attributes-of-confirmed-cases'"
           :chart-data="patientsTable"
           :chart-option="{}"


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #{171}

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 患者と感染者双方を含む人数をカウントしている項目のタイトルで入院患者数及び陽性患者数となっている部分について、それぞれを入院者数と陽性者数に変更。
