### PR TITLE
「新型コロナウイルス感染症が心配なときに」のリンク先を県の提供するページに変更のURLの変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -140,7 +140,7 @@ export default {
             'For those concerned about novel coronavirus infections'
           ),
           link:
-            'http://www.pref.nara.jp/secure/226888/nara20200501coronanagare.pdf'
+            'http://www.pref.nara.jp/secure/226888/02_相談や受診の流れ0515.pdf'
         },
         {
           icon: 'mdi-account-multiple',

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -139,7 +139,8 @@ export default {
           title: this.$t(
             'For those concerned about novel coronavirus infections'
           ),
-          link: this.localePath('/flow')
+          link:
+            'http://www.pref.nara.jp/secure/226888/nara20200501coronanagare.pdf'
         },
         {
           icon: 'mdi-account-multiple',

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -46,7 +46,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script>
 import { convertDateToISO8601Format } from '@/utils/formatDate'
 import ExternalLink from '@/components/ExternalLink.vue'
 


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #231

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
-  PR#232の「新型コロナウイルス感染症が心配なときに」のリンク先を県の提供するページに変更で行う予定のリンク先のファイルが、更に更新されたとのことで、再変更します。

リンクの貼られている場所：サイドバーの「新型コロナウイルス感染症が心配なときに」
修正前のリンク先(内部ページ)：https://stopcovid19.code4nara.org/flow
修正後のリンク先(外部リンク)：http://www.pref.nara.jp/secure/226888/nara20200501coronanagare.pdf
再修正後のリンク先(外部リンク)：http://www.pref.nara.jp/secure/226888/02_相談や受診の流れ0515.pdf

