### PR TITLE
各グラフ左下の「奈良県の公開情報を利用」のリンク先を奈良県のオープンデータ公開ページに変更する

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,8 +8,8 @@
     <whats-new class="mb-4" :items="newsItems" />
     <v-row class="DataBlock">
       <confirmed-cases-details-card
-        :source-url="'http://www.pref.nara.jp/1652.htm'"
-        :source-text="'奈良県の公開情報を利用'"
+        :source-url="'http://www.pref.nara.jp/55168.htm'"
+        :source-text="'奈良県のオープンデータを利用'"
       />
       <!-- <v-col cols="12" md="6" class="DataCard">
         <svg-card
@@ -32,8 +32,8 @@
           :date="Data.patients_summary.date"
           :unit="'人'"
           :url="'http://www.pref.nara.jp/'"
-          :source-url="'http://www.pref.nara.jp/1652.htm'"
-          :source-text="'奈良県の公開情報を利用'"
+          :source-url="'http://www.pref.nara.jp/55168.htm'"
+          :source-text="'奈良県のオープンデータを利用'"
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -45,8 +45,8 @@
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
           :url="'http://www.pref.nara.jp/'"
-          :source-url="'http://www.pref.nara.jp/1652.htm'"
-          :source-text="'奈良県の公開情報を利用'"
+          :source-url="'http://www.pref.nara.jp/55168.htm'"
+          :source-text="'奈良県のオープンデータを利用'"
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -57,8 +57,8 @@
           :chart-data="inspectionsGraph"
           :date="Data.inspections.date"
           :unit="'件'"
-          :source-url="'http://www.pref.nara.jp/1652.htm'"
-          :source-text="'奈良県の公開情報を利用'"
+          :source-url="'http://www.pref.nara.jp/55168.htm'"
+          :source-text="'奈良県のオープンデータを利用'"
         />
       </v-col>
       <!--
@@ -86,8 +86,8 @@
       </v-col>
       -->
       <patients-and-sickbeds
-        :source-url="'http://www.pref.nara.jp/'"
-        :source-text="'奈良県の公開情報を利用'"
+        :source-url="'http://www.pref.nara.jp/55168.htm'"
+        :source-text="'奈良県のオープンデータを利用'"
         :date="Data.sickbeds_summary.date"
       />
     </v-row>


### PR DESCRIPTION
「奈良県の公開情報を利用」の文言も「奈良県のオープンデータを利用」に変更しました。

## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #256

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 各グラフの左下「奈良県の公開情報を利用」のリンク先を奈良県のオープンデータ公開ページに変更しました。
- リンク先の変更と併せて、「奈良県の公開情報を利用」から「奈良県のオープンデータを利用」に文言の変更も行いました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/35659901/83872751-8f8edd80-a76d-11ea-9e9c-77714befb4de.png)
