### PR TITLE
Fix broken external link

### DIFF
--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -31,7 +31,7 @@ export default {
         },
         {
           title: '新型コロナウイルス感染症対策　経営相談窓口（奈良県）',
-          link: 'http://www.pref.nara.jp/#007',
+          link: 'http://www.pref.nara.jp/55413.htm#015',
           body:
             '新型コロナウイルス感染症に関連して、労働問題で困ったことがあれば、ご相談ください。'
         }


### PR DESCRIPTION
"新型コロナウイルス感染症対策　経営相談窓口（奈良県）"のリンク先がリンク切れとなっていたため現在の相談窓口のURLに変更した。

## 📝 関連issue / Related Issues
#326
<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- "新型コロナウイルス感染症対策　経営相談窓口（奈良県）"のリンク先を現在のもの(  http://www.pref.nara.jp/55413.htm#015  )に更新した

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
